### PR TITLE
feat: make increment endpoint configurable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ The component does a great job submitting and fetching questions from the audien
 
 When a user submits a question, the component will post the following object to the configured endpoint.
 
-```json
+```js
 {
   /**
    * The question the user asked
@@ -67,7 +67,7 @@ When a user submits a question, the component will post the following object to 
 
 The component will fetch a list of questions asked from the backend at a configurable interval of time. These questions can look like the question above, but should also include two additional manditory fields.
 
-```json
+````js
 [
   {
     /**
@@ -90,20 +90,20 @@ The component will fetch a list of questions asked from the backend at a configu
      * Optional correlation id, if configured for the component
      */
     "correlationId": "keynote-talk"
-  }
-]
+  },
+];
 ```
 
 ### Incrementing a questions count
 
 When a user clicks on a `+1` button for a question, they are saying "I also want to know the answer to this question". These +1s are posted to the backend with the following shape. The `userId` is an optional field that will be sent if it is configured for the component. This way you can prevent users from spamming the +1s on a question, or see who all voted for the question.
 
-```json
+```js
 {
   "key": "question1",
   "userId": "user-4"
 }
-```
+````
 
 ## Development
 

--- a/readme.md
+++ b/readme.md
@@ -67,7 +67,7 @@ When a user submits a question, the component will post the following object to 
 
 The component will fetch a list of questions asked from the backend at a configurable interval of time. These questions can look like the question above, but should also include two additional manditory fields.
 
-````js
+```js
 [
   {
     /**

--- a/src/components/q-and-a/q-and-a.tsx
+++ b/src/components/q-and-a/q-and-a.tsx
@@ -12,14 +12,18 @@ import state from '../../store';
 export class QAndA {
   /**
    * The endpoint that questions/upvotes will be posted to.
-   * Defaults to `/ask` if not defined
+   * Defaults to `/ask` if not defined.
    */
   @Prop() askEndpoint: string;
   /**
    * The endpoint the list of questions will be retrieved from.
-   * Defaults to `/questions` if not defined
+   * Defaults to `/questions` if not defined.
    */
   @Prop() retrieveEndpoint: string;
+  /**
+   * The endpoint to post increment commands to. Defaults to `/ask` if not defined.
+   */
+  @Prop() incrementEndpoint: string;
   /**
    * The optional id of the user asking a question. Will be sent with the question if present. Cannot be changed once initialized.
    */
@@ -47,6 +51,9 @@ export class QAndA {
     }
     if (this.retrieveEndpoint) {
       state.retrieveEndpoint = this.retrieveEndpoint;
+    }
+    if (this.incrementEndpoint) {
+      state.incrementEndpoint = this.incrementEndpoint;
     }
     if (this.userId) {
       state.userId = this.userId;

--- a/src/components/q-and-a/test/__snapshots__/q-and-a.spec.tsx.snap
+++ b/src/components/q-and-a/test/__snapshots__/q-and-a.spec.tsx.snap
@@ -40,6 +40,7 @@ exports[`q-and-a should set the state according to the properties supplied 2`] =
 Object {
   "askEndpoint": "/test-endpoint",
   "correlationId": "corr123",
+  "incrementEndpoint": "/ask",
   "primaryColor": "#585859",
   "questions": Array [],
   "retrieveEndpoint": "/test-retrieve",
@@ -52,6 +53,7 @@ exports[`q-and-a should update the correlation id if it changes 1`] = `
 Object {
   "askEndpoint": "/ask",
   "correlationId": "",
+  "incrementEndpoint": "/ask",
   "primaryColor": "#10915b",
   "questions": Array [],
   "retrieveEndpoint": "/questions",
@@ -64,6 +66,7 @@ exports[`q-and-a should update the correlation id if it changes 2`] = `
 Object {
   "askEndpoint": "/ask",
   "correlationId": "corr1234",
+  "incrementEndpoint": "/ask",
   "primaryColor": "#10915b",
   "questions": Array [],
   "retrieveEndpoint": "/questions",

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,6 +3,7 @@ import { createStore } from '@stencil/store';
 const { state, reset, dispose } = createStore({
   askEndpoint: '/ask',
   retrieveEndpoint: '/questions',
+  incrementEndpoint: '/ask',
   userId: '',
   correlationId: '',
   primaryColor: '#10915b',

--- a/src/utils/data-fetching-utils.ts
+++ b/src/utils/data-fetching-utils.ts
@@ -51,7 +51,7 @@ export async function incrementQuestionCount(key: string): Promise<void> {
     },
     body: JSON.stringify(request),
   };
-  await fetch(state.askEndpoint, settings);
+  await fetch(state.incrementEndpoint, settings);
 }
 
 /**


### PR DESCRIPTION
Users are now able to configure the endpoint increment calls post to.

Implements #7
