### PR TITLE
fix: improve a11y and move defaults from store into component props

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,31 +8,35 @@ import { HTMLStencilElement, JSXBase } from '@stencil/core/internal';
 export namespace Components {
   interface QAndA {
     /**
-     * The endpoint that questions/upvotes will be posted to. Defaults to `/ask` if not defined
+     * The endpoint that questions/upvotes will be posted to.
      */
     askEndpoint: string;
     /**
-     * The correlation id of the q-and-a session. If present, will be sent with questions and used to retrieve questions by appending a `correlationId` query parameter to the `retrieveEndpoint` url. A good use case for this property is to track which talk is being given at a time. This way you can only display questions relevant to the current talk.
+     * The correlation id of the q-and-a session. If present, will be sent with questions and used to retrieve questions by appending a `correlationId` query parameter to the `retrieveEndpoint` url. Changes to this property are tracked and updated within the component. A good use case for this property is to track which talk is being given at a time. This way you can only display questions relevant to the current talk.
      */
     correlationId: string;
+    /**
+     * The endpoint to post increment commands to.
+     */
+    incrementEndpoint: string;
     /**
      * The interval in which the questions should be fetched in ms. Defaults to 10000ms (10 seconds).
      */
     pollingInterval: number;
     /**
-     * Primary color. Used mainly for button borders. Defaults to #10915b
+     * Primary color. Used mainly for button borders.
      */
     primaryColor: string;
     /**
-     * The endpoint the list of questions will be retrieved from. Defaults to `/questions` if not defined
+     * The endpoint the list of questions will be retrieved from.
      */
     retrieveEndpoint: string;
     /**
-     * Secondary color. Used for question and header text color. Defaults to  #112378
+     * Secondary color. Used for question and header text color.
      */
     secondaryColor: string;
     /**
-     * The optional id of the user asking a question. Will be sent with the question if present.
+     * The optional id of the user asking a question. Will be sent with the question if present. Cannot be changed once initialized.
      */
     userId: string;
   }
@@ -57,31 +61,35 @@ declare global {
 declare namespace LocalJSX {
   interface QAndA {
     /**
-     * The endpoint that questions/upvotes will be posted to. Defaults to `/ask` if not defined
+     * The endpoint that questions/upvotes will be posted to.
      */
     askEndpoint?: string;
     /**
-     * The correlation id of the q-and-a session. If present, will be sent with questions and used to retrieve questions by appending a `correlationId` query parameter to the `retrieveEndpoint` url. A good use case for this property is to track which talk is being given at a time. This way you can only display questions relevant to the current talk.
+     * The correlation id of the q-and-a session. If present, will be sent with questions and used to retrieve questions by appending a `correlationId` query parameter to the `retrieveEndpoint` url. Changes to this property are tracked and updated within the component. A good use case for this property is to track which talk is being given at a time. This way you can only display questions relevant to the current talk.
      */
     correlationId?: string;
+    /**
+     * The endpoint to post increment commands to.
+     */
+    incrementEndpoint?: string;
     /**
      * The interval in which the questions should be fetched in ms. Defaults to 10000ms (10 seconds).
      */
     pollingInterval?: number;
     /**
-     * Primary color. Used mainly for button borders. Defaults to #10915b
+     * Primary color. Used mainly for button borders.
      */
     primaryColor?: string;
     /**
-     * The endpoint the list of questions will be retrieved from. Defaults to `/questions` if not defined
+     * The endpoint the list of questions will be retrieved from.
      */
     retrieveEndpoint?: string;
     /**
-     * Secondary color. Used for question and header text color. Defaults to  #112378
+     * Secondary color. Used for question and header text color.
      */
     secondaryColor?: string;
     /**
-     * The optional id of the user asking a question. Will be sent with the question if present.
+     * The optional id of the user asking a question. Will be sent with the question if present. Cannot be changed once initialized.
      */
     userId?: string;
   }

--- a/src/components/QuestionList/test/qa-question-list.spec.tsx
+++ b/src/components/QuestionList/test/qa-question-list.spec.tsx
@@ -1,20 +1,28 @@
-import {QuestionList} from '../QuestionList';
+import { QuestionList } from '../QuestionList';
+import state, { disposeStore } from '../../../store';
 
+beforeEach(() => {
+  disposeStore();
+  state.primaryColor = '#10915b';
+  state.secondaryColor = '#112378';
+});
 
 describe('qa-question-list', () => {
   it('renders no questions when none are present', async () => {
-    const result = QuestionList({questions: []}, [], undefined);
+    const result = QuestionList({ questions: [] }, [], undefined);
     expect(result).toMatchSnapshot();
   });
 
   it('renders all of the questions', () => {
-    const questions = [{
-      key:'key1',
-      question: 'What time is it?',
-      count: 20
-    }];
-    
-    const result = QuestionList({questions}, [], undefined);
+    const questions = [
+      {
+        key: 'key1',
+        question: 'What time is it?',
+        count: 20,
+      },
+    ];
+
+    const result = QuestionList({ questions }, [], undefined);
     expect(result).toMatchSnapshot();
-  })
+  });
 });

--- a/src/components/q-and-a/q-and-a.tsx
+++ b/src/components/q-and-a/q-and-a.tsx
@@ -12,18 +12,16 @@ import state from '../../store';
 export class QAndA {
   /**
    * The endpoint that questions/upvotes will be posted to.
-   * Defaults to `/ask` if not defined.
    */
-  @Prop() askEndpoint: string;
+  @Prop() askEndpoint: string = '/ask';
   /**
    * The endpoint the list of questions will be retrieved from.
-   * Defaults to `/questions` if not defined.
    */
-  @Prop() retrieveEndpoint: string;
+  @Prop() retrieveEndpoint: string = '/questions';
   /**
-   * The endpoint to post increment commands to. Defaults to `/ask` if not defined.
+   * The endpoint to post increment commands to.
    */
-  @Prop() incrementEndpoint: string;
+  @Prop() incrementEndpoint: string = '/ask';
   /**
    * The optional id of the user asking a question. Will be sent with the question if present. Cannot be changed once initialized.
    */
@@ -33,13 +31,13 @@ export class QAndA {
    */
   @Prop() correlationId: string;
   /**
-   * Primary color. Used mainly for button borders. Defaults to #10915b
+   * Primary color. Used mainly for button borders.
    */
-  @Prop() primaryColor: string;
+  @Prop() primaryColor: string = '#007745 ';
   /**
-   * Secondary color. Used for question and header text color. Defaults to  #112378
+   * Secondary color. Used for question and header text color.
    */
-  @Prop() secondaryColor: string;
+  @Prop() secondaryColor: string = '#112378';
   /**
    * The interval in which the questions should be fetched in ms. Defaults to 10000ms (10 seconds).
    */

--- a/src/components/q-and-a/test/__snapshots__/q-and-a.spec.tsx.snap
+++ b/src/components/q-and-a/test/__snapshots__/q-and-a.spec.tsx.snap
@@ -8,7 +8,7 @@ exports[`q-and-a renders 1`] = `
         <form id="qa-question-form">
           <div><textarea aria-label="Submit your question here" cols="30" id="question" name="question" rows="3"></textarea>
           </div>
-          <button id="qa-submit-question-btn" type="submit" style="color: #10915b; border: 3px solid #10915b;">
+          <button id="qa-submit-question-btn" type="submit" style="color: #007745 ; border: 3px solid #007745 ;">
             Ask Question
           </button>
         </form>
@@ -54,7 +54,7 @@ Object {
   "askEndpoint": "/ask",
   "correlationId": "",
   "incrementEndpoint": "/ask",
-  "primaryColor": "#10915b",
+  "primaryColor": "#007745 ",
   "questions": Array [],
   "retrieveEndpoint": "/questions",
   "secondaryColor": "#112378",
@@ -67,7 +67,7 @@ Object {
   "askEndpoint": "/ask",
   "correlationId": "corr1234",
   "incrementEndpoint": "/ask",
-  "primaryColor": "#10915b",
+  "primaryColor": "#007745 ",
   "questions": Array [],
   "retrieveEndpoint": "/questions",
   "secondaryColor": "#112378",

--- a/src/components/qa-question-form/test/qa-question-form.spec.tsx
+++ b/src/components/qa-question-form/test/qa-question-form.spec.tsx
@@ -1,7 +1,13 @@
 import { newSpecPage } from '@stencil/core/testing';
 import { QaQuestionForm } from '../qa-question-form';
+import state, { disposeStore } from '../../../store';
 
 describe('qa-question-form', () => {
+  beforeEach(() => {
+    disposeStore();
+    state.primaryColor = '#10915b';
+  });
+
   it('renders', async () => {
     const page = await newSpecPage({
       components: [QaQuestionForm],

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,8 @@
     <script nomodule src="/build/q-and-a.js"></script>
   </head>
   <body>
-    <q-and-a user-id="brenden" correlation-id="my-talk"></q-and-a>
+    <main>
+      <q-and-a user-id="brenden" correlation-id="my-talk"></q-and-a>
+    </main>
   </body>
 </html>

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,13 +1,20 @@
 import { createStore } from '@stencil/store';
 
+// use these questions in the store below to create some default examples to see during development.
+/* const questions = [
+  { question: 'What time is lunch?', count: 3, key: '1' },
+  { question: 'What is your favorite color?', count: 1, key: '2' },
+  { question: 'What is your favorite band?', count: 2, key: '3' },
+]; */
+
 const { state, reset, dispose } = createStore({
-  askEndpoint: '/ask',
-  retrieveEndpoint: '/questions',
-  incrementEndpoint: '/ask',
+  askEndpoint: '',
+  retrieveEndpoint: '',
+  incrementEndpoint: '',
   userId: '',
   correlationId: '',
-  primaryColor: '#10915b',
-  secondaryColor: '#112378',
+  primaryColor: '',
+  secondaryColor: '',
   questions: [],
 });
 /** Used to reset the store to its original shape */

--- a/src/utils/test/data-fetching-utils.spec.ts
+++ b/src/utils/test/data-fetching-utils.spec.ts
@@ -1,6 +1,5 @@
 import fetchMock from 'fetch-mock-jest';
 import { askQuestion, incrementQuestionCount, fetchQuestions } from '../data-fetching-utils';
-
 import state, { disposeStore } from '../../store';
 import { AskedQuestion } from '../../models/Question';
 
@@ -11,6 +10,7 @@ beforeEach(() => {
 
 describe('askQuestion', () => {
   beforeEach(() => {
+    state.askEndpoint = '/ask';
     fetchMock.post(state.askEndpoint, (_url, options) => {
       if (options.body.length > 0) {
         return 200;
@@ -34,7 +34,8 @@ describe('askQuestion', () => {
 
 describe('incrementQuestionCount', () => {
   beforeEach(() => {
-    fetchMock.post(state.askEndpoint, (_url, options) => {
+    state.incrementEndpoint = '/ask';
+    fetchMock.post(state.incrementEndpoint, (_url, options) => {
       if (options.body.length > 0) {
         return 200;
       }
@@ -59,6 +60,11 @@ describe('fetchQuestions', () => {
     { question: 'What time is it?', count: 2, key: '1', userId: 'user1', correlationId: 'a123' },
     { question: 'What is for lunch?', count: 0, key: '2', userId: '1', correlationId: 'a123' },
   ];
+
+  beforeEach(() => {
+    state.retrieveEndpoint = '/questions';
+  });
+
   it('should fetch the questions and set them in the state', async () => {
     fetchMock.get(
       state.retrieveEndpoint,


### PR DESCRIPTION
This change addresses accessibility issues found in an axe audit. It also moves the default values
for the component properties out of the initial store state and into the component itself. This
helps make documentation clearer.

Closes #9
